### PR TITLE
Typo fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ This project enables running the Project Wycheproof test vectors on PKCS #11 dev
 
 ### Steps
     git clone https://github.com/awslabs/pkcs11-runners-for-project-wycheproof.git
-    mkdir build-pkcs11-runners-for-project-wycheproof && cd pkcs11-runners-for-project-wycheproof
+    mkdir build-pkcs11-runners-for-project-wycheproof && cd build-pkcs11-runners-for-project-wycheproof
     cmake ../pkcs11-runners-for-project-wycheproof
     make
 

--- a/include/common.h
+++ b/include/common.h
@@ -84,7 +84,7 @@ static inline void* fillAttrParamConst(void* dst, uint64_t src, size_t size) {
     COPY_CONST_VAL(dst, src, uint64_t);
     break;
   default:
-    printf("Unknown size: %d\n", size);
+    printf("Unknown size: %zd\n", size);
     return NULL;
   }
   return dst;


### PR DESCRIPTION
Typo fix to build instructions in README.md and fix to format string in common.h


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
